### PR TITLE
NP-816: Rename GateException to HttpClientFailureException

### DIFF
--- a/src/main/java/no/unit/nva/institution/proxy/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/institution/proxy/CristinApiClient.java
@@ -2,7 +2,7 @@ package no.unit.nva.institution.proxy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
 import no.unit.nva.institution.proxy.response.InstitutionListResponse;
@@ -23,7 +23,7 @@ public class CristinApiClient {
         this.httpExecutor = httpExecutor;
     }
 
-    public InstitutionListResponse getInstitutions(Language language) throws GatewayException {
+    public InstitutionListResponse getInstitutions(Language language) throws HttpClientFailureException {
         return httpExecutor.getInstitutions(language);
     }
 
@@ -33,11 +33,11 @@ public class CristinApiClient {
      * @param uri      The URI of the institution's Unit
      * @param language a valid Language. See {@link Language}.
      * @return A list of all the units that are descendants of the institution unit
-     * @throws GatewayException    when an Exception occurs.
-     * @throws InvalidUriException when the input URI is invalid.
+     * @throws HttpClientFailureException when an Exception occurs.
+     * @throws InvalidUriException        when the input URI is invalid.
      */
     public JsonNode getNestedInstitution(URI uri, Language language)
-        throws GatewayException, InvalidUriException {
+        throws HttpClientFailureException, InvalidUriException {
         return httpExecutor.getNestedInstitution(uri, language);
     }
 
@@ -47,12 +47,12 @@ public class CristinApiClient {
      * @param uri      the Cristin unit URI
      * @param language a language code for the details of each unit
      * @return an {@link JsonNode} containing the information in JSON-LD form
-     * @throws InterruptedException when the http client throws an {@link InterruptedException } exception
-     * @throws NonExistingUnitError when the URI does not correspond to an existing unit.
-     * @throws GatewayException     when Cristin server reports failure
+     * @throws InterruptedException       when the http client throws an {@link InterruptedException } exception
+     * @throws NonExistingUnitError       when the URI does not correspond to an existing unit.
+     * @throws HttpClientFailureException when Cristin server reports failure
      */
     public JsonNode getSingleUnit(URI uri, Language language)
-        throws InterruptedException, NonExistingUnitError, GatewayException {
+        throws InterruptedException, NonExistingUnitError, HttpClientFailureException {
         logger.info("Fetching resutls for: " + uri.toString());
         JsonNode result = httpExecutor.getSingleUnit(uri, language);
         return result;

--- a/src/main/java/no/unit/nva/institution/proxy/HttpExecutor.java
+++ b/src/main/java/no/unit/nva/institution/proxy/HttpExecutor.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.net.http.HttpResponse;
 import no.unit.nva.institution.proxy.exception.FailedHttpRequestException;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
 import no.unit.nva.institution.proxy.response.InstitutionListResponse;
@@ -20,13 +20,13 @@ public abstract class HttpExecutor {
     public static int FIRST_SUCCESSFUL_CODE = HttpStatus.SC_OK;
     public static String NULL_HTTP_RESPONSE_ERROR_MESSAGE = "No HttpResponse found";
 
-    public abstract InstitutionListResponse getInstitutions(Language language) throws GatewayException;
+    public abstract InstitutionListResponse getInstitutions(Language language) throws HttpClientFailureException;
 
     public abstract JsonNode getNestedInstitution(URI uri, Language language)
-        throws GatewayException, InvalidUriException;
+        throws HttpClientFailureException, InvalidUriException;
 
     public abstract JsonNode getSingleUnit(URI uri, Language language)
-        throws NonExistingUnitError, GatewayException, InterruptedException;
+        throws NonExistingUnitError, HttpClientFailureException, InterruptedException;
 
     protected HttpResponse<String> throwExceptionIfNotSuccessful(HttpResponse<String> response)
         throws FailedHttpRequestException {

--- a/src/main/java/no/unit/nva/institution/proxy/exception/HttpClientFailureException.java
+++ b/src/main/java/no/unit/nva/institution/proxy/exception/HttpClientFailureException.java
@@ -3,15 +3,15 @@ package no.unit.nva.institution.proxy.exception;
 import nva.commons.exceptions.ApiGatewayException;
 import org.apache.http.HttpStatus;
 
-public class GatewayException extends ApiGatewayException {
+public class HttpClientFailureException extends ApiGatewayException {
 
     public static final int ERROR_CODE = HttpStatus.SC_BAD_GATEWAY;
 
-    public GatewayException(String message) {
+    public HttpClientFailureException(String message) {
         super(message);
     }
 
-    public GatewayException(Exception cause) {
+    public HttpClientFailureException(Exception cause) {
         super(cause);
     }
 

--- a/src/main/java/no/unit/nva/institution/proxy/handler/InstitutionListHandler.java
+++ b/src/main/java/no/unit/nva/institution/proxy/handler/InstitutionListHandler.java
@@ -2,7 +2,7 @@ package no.unit.nva.institution.proxy.handler;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import no.unit.nva.institution.proxy.CristinApiClient;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.UnknownLanguageException;
 import no.unit.nva.institution.proxy.response.InstitutionListResponse;
 import no.unit.nva.institution.proxy.utils.LanguageMapper;
@@ -34,7 +34,7 @@ public class InstitutionListHandler extends ApiGatewayHandler<Void, InstitutionL
     @Override
     protected InstitutionListResponse processInput(Void input, RequestInfo requestInfo,
                                                    Context context)
-        throws UnknownLanguageException, GatewayException {
+        throws UnknownLanguageException, HttpClientFailureException {
         String languageParameter = requestInfo.getQueryParameters().get(LANGUAGE_QUERY_PARAMETER);
         LanguageMapper languageMapper = new LanguageMapper();
         return cristinApiClient.getInstitutions(languageMapper.getLanguage(languageParameter));

--- a/src/test/java/no/unit/nva/institution/proxy/CristinApiClientTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/CristinApiClientTest.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.JsonParsingException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
@@ -47,7 +47,7 @@ public class CristinApiClientTest {
     @DisplayName("getNestedInstitution returns nested institution when input is valid")
     @Test
     void getNestedInstitutionReturnsNestedInstitutionWhenInputIsValid()
-        throws InvalidUriException, GatewayException, JsonParsingException {
+        throws InvalidUriException, HttpClientFailureException, JsonParsingException {
         HttpExecutor mockHttpExecutor = mock(HttpExecutorImpl.class);
         ObjectNode mockResponse = simpleJsonObject();
         when(mockHttpExecutor.getNestedInstitution(any(), any()))
@@ -59,7 +59,7 @@ public class CristinApiClientTest {
 
     @DisplayName("getInstitutions returns a list with Institutions when input is valid")
     @Test
-    void getInstitutionsReturnsAListWithInstitutionsWhenInputIsValid() throws GatewayException {
+    void getInstitutionsReturnsAListWithInstitutionsWhenInputIsValid() throws HttpClientFailureException {
         InstitutionResponse mockResponseItem = new InstitutionResponse.Builder()
             .withId(VALID_URI)
             .withName(SOME_NAME)
@@ -75,7 +75,7 @@ public class CristinApiClientTest {
 
     @DisplayName("getInstitutions returns a list with Institutions and each institution has an acronym")
     @Test
-    void getInstitutionsReturnsInstitutionsWithAcronymIfInstitutionsHaveAcronyms() throws GatewayException {
+    void getInstitutionsReturnsInstitutionsWithAcronymIfInstitutionsHaveAcronyms() throws HttpClientFailureException {
         InstitutionResponse mockResponseItem = new InstitutionResponse.Builder()
             .withId(VALID_URI)
             .withName(SOME_NAME)
@@ -93,7 +93,7 @@ public class CristinApiClientTest {
     @Test
     @DisplayName("getSingleUnit returns the graph of a unit")
     public void getSingleUnitReturnsTheGraphOfAUnit()
-        throws InterruptedException, GatewayException, NonExistingUnitError, JsonProcessingException {
+        throws InterruptedException, HttpClientFailureException, NonExistingUnitError, JsonProcessingException {
         HttpExecutorImpl httpExecutor = new HttpExecutorImpl(new HttpClientReturningInfoOfSingleUnits());
         CristinApiClient cristinApiClient = new CristinApiClient(httpExecutor);
 

--- a/src/test/java/no/unit/nva/institution/proxy/HttpExecutorImplTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/HttpExecutorImplTest.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import no.unit.nva.institution.proxy.exception.FailedHttpRequestException;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.JsonParsingException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
@@ -122,7 +122,7 @@ public class HttpExecutorImplTest {
 
         HttpExecutorImpl executor = new HttpExecutorImpl(httpClientReturnsError());
 
-        GatewayException exception = assertThrows(GatewayException.class,
+        HttpClientFailureException exception = assertThrows(HttpClientFailureException.class,
             () -> executor.getInstitutions(Language.ENGLISH));
 
         Throwable cause = exception.getCause();
@@ -137,19 +137,19 @@ public class HttpExecutorImplTest {
 
         HttpExecutorImpl executor = new HttpExecutorImpl(httpClientWithResponseBody(INVALID_JSON_STR));
 
-        GatewayException exception = assertThrows(GatewayException.class,
+        HttpClientFailureException exception = assertThrows(HttpClientFailureException.class,
             () -> executor.getInstitutions(Language.ENGLISH));
 
         Throwable cause = exception.getCause();
         assertThat(cause.getClass(), is(equalTo(IOException.class)));
-        assertThat(exception.getStatusCode(), is(equalTo(GatewayException.ERROR_CODE)));
+        assertThat(exception.getStatusCode(), is(equalTo(HttpClientFailureException.ERROR_CODE)));
         assertThat(exception.getMessage(), containsString(INVALID_JSON_STR));
     }
 
     @DisplayName("getNestedInstitution returns nested institution when input is valid")
     @Test
     void getNestedInstitutionReturnsNestedInstitutionWhenUriAndLanguageAreValid()
-        throws InvalidUriException, GatewayException, JsonParsingException, IOException {
+        throws InvalidUriException, HttpClientFailureException, JsonParsingException, IOException {
         HttpClient client = new HttpClientGetsNestedInstitutionResponse(Language.ENGLISH).getMockClient();
         HttpExecutorImpl executor = new HttpExecutorImpl(client);
         JsonNode response = executor.getNestedInstitution(URI.create(INSTITUTION_REQUEST_URI),
@@ -162,7 +162,7 @@ public class HttpExecutorImplTest {
 
     @Test
     void getSingleUnitReturnsANestedInstitutionResponseWhenInputIsValid()
-        throws InterruptedException, GatewayException, NonExistingUnitError,
+        throws InterruptedException, HttpClientFailureException, NonExistingUnitError,
                JsonParsingException, JsonProcessingException {
         HttpClient mockHttpClient = new HttpClientReturningInfoOfSingleUnits();
         HttpExecutorImpl executor = new HttpExecutorImpl(mockHttpClient);

--- a/src/test/java/no/unit/nva/institution/proxy/HttpExecutorTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/HttpExecutorTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.net.http.HttpResponse;
 import no.unit.nva.institution.proxy.exception.FailedHttpRequestException;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.response.InstitutionListResponse;
 import no.unit.nva.institution.proxy.utils.Language;
 import org.apache.http.HttpStatus;
@@ -31,7 +31,7 @@ public class HttpExecutorTest {
         }
 
         @Override
-        public JsonNode getNestedInstitution(URI uri, Language language) throws GatewayException {
+        public JsonNode getNestedInstitution(URI uri, Language language) throws HttpClientFailureException {
             return null;
         }
 

--- a/src/test/java/no/unit/nva/institution/proxy/SingleUnitHierarchyGeneratorTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/SingleUnitHierarchyGeneratorTest.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.JsonParsingException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
@@ -55,7 +55,8 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with single item when input item has no parents")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithSingleItemWhenInputItemHasNoParents()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, GatewayException, JsonParsingException,
+        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
+               JsonParsingException,
                JsonProcessingException {
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(ROOT_NODE_URI, TESTING_LANGUAGE,
             mockHttpClient);
@@ -68,7 +69,7 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with two items when input item is a level one child")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithTwoItemsWhenInputItemIsALevelOneChild()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, GatewayException,
+        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
                JsonProcessingException, JsonParsingException {
 
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(FIRST_LEVEL_CHILD_URI,
@@ -81,7 +82,8 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with 3 items when input item is a level two child")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithThreeItemsWhenInputItemIsALevelTwoChild()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, GatewayException, JsonParsingException,
+        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
+               JsonParsingException,
                JsonProcessingException {
 
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(SECOND_LEVEL_CHILD_URI,

--- a/src/test/java/no/unit/nva/institution/proxy/exception/HttpClientFailureExceptionTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/exception/HttpClientFailureExceptionTest.java
@@ -7,12 +7,12 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-public class GatewayExceptionTest {
+public class HttpClientFailureExceptionTest {
 
     @Test
     public void gatewayExceptionHasConstructorWithStringOnly() {
         String message = "someMessage";
-        GatewayException exception = new GatewayException(message);
+        HttpClientFailureException exception = new HttpClientFailureException(message);
         assertThat(exception.getMessage(), is(equalTo(message)));
         assertThat(exception.getStatusCode(), is(equalTo(HttpStatus.SC_BAD_GATEWAY)));
     }

--- a/src/test/java/no/unit/nva/institution/proxy/handler/InstitutionListHandlerTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/handler/InstitutionListHandlerTest.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
 import no.unit.nva.institution.proxy.CristinApiClient;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.UnknownLanguageException;
 import no.unit.nva.institution.proxy.response.InstitutionListResponse;
 import no.unit.nva.institution.proxy.utils.Language;
@@ -119,7 +119,7 @@ public class InstitutionListHandlerTest extends HandlerTest {
     @DisplayName("handleRequest returns BadGateway to the client when GatewayException occurs")
     @Test
     public void handleRequestReturnsBadGatewayToTheClientWhnGatewayExceptionOccurs()
-        throws IOException, GatewayException {
+        throws IOException, HttpClientFailureException {
         InstitutionListHandler handler = handlerThatThrowsInstitutionFailureException(SOME_EXCEPTION_MESSAGE);
         InputStream inputStream = inputValidLanguageCode();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -166,10 +166,10 @@ public class InstitutionListHandlerTest extends HandlerTest {
     }
 
     private InstitutionListHandler handlerThatThrowsInstitutionFailureException(String exceptionMessage)
-        throws GatewayException {
+        throws HttpClientFailureException {
         CristinApiClient cristinClient = mock(CristinApiClient.class);
         IOException cause = new IOException(exceptionMessage);
-        when(cristinClient.getInstitutions(any(Language.class))).thenThrow(new GatewayException(cause));
+        when(cristinClient.getInstitutions(any(Language.class))).thenThrow(new HttpClientFailureException(cause));
         return new InstitutionListHandler(environment, cristinClient);
     }
 
@@ -213,7 +213,7 @@ public class InstitutionListHandlerTest extends HandlerTest {
         @Override
         protected InstitutionListResponse processInput(Void input, RequestInfo requestInfo,
                                                        Context context)
-            throws UnknownLanguageException, GatewayException {
+            throws UnknownLanguageException, HttpClientFailureException {
             this.languageQueryParameter = requestInfo.getQueryParameters()
                 .get(InstitutionListHandler.LANGUAGE_QUERY_PARAMETER);
             return super.processInput(input, requestInfo, context);

--- a/src/test/java/no/unit/nva/institution/proxy/handler/NestedInstitutionHandlerTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/handler/NestedInstitutionHandlerTest.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import no.unit.nva.institution.proxy.CristinApiClient;
-import no.unit.nva.institution.proxy.exception.GatewayException;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.JsonParsingException;
 import no.unit.nva.institution.proxy.exception.MissingParameterException;
@@ -255,7 +255,7 @@ public class NestedInstitutionHandlerTest extends HandlerTest {
     @DisplayName("handleRequest returns BadGateway to the client when GatewayException occurs")
     @Test
     public void handleRequestReturnsBadRequestWhenInstitutionFailureOccurs()
-        throws IOException, InvalidUriException, GatewayException, JsonParsingException {
+        throws IOException, InvalidUriException, HttpClientFailureException, JsonParsingException {
         NestedInstitutionHandler handler = handlerThatThrowsNestedInstitutionFailureException(SOME_EXCEPTION_MESSAGE);
         InputStream inputStream = inputInstitutionsRequest();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -269,11 +269,11 @@ public class NestedInstitutionHandlerTest extends HandlerTest {
     }
 
     private NestedInstitutionHandler handlerThatThrowsNestedInstitutionFailureException(String message)
-        throws InvalidUriException, GatewayException, JsonParsingException {
+        throws InvalidUriException, HttpClientFailureException, JsonParsingException {
         CristinApiClient cristinClient = mock(CristinApiClient.class);
         IOException cause = new IOException(message);
         when(cristinClient.getNestedInstitution(any(URI.class), any(Language.class)))
-            .thenThrow(new GatewayException(cause));
+            .thenThrow(new HttpClientFailureException(cause));
         return new NestedInstitutionHandler(environment, cristinClient);
     }
 


### PR DESCRIPTION
Rename GatewayException to HttpClientFailureException.
GatewayException occurs when Java HttpClient throws an Exception. GatewayException is a bit  confusing and can lead people to think that there is ApiGateway error.  The new name of the exception is more descriptive.