### PR TITLE
Np 711 retry getting when failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ def junitVersion= "5.6.2"
 dependencies {
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-lambda', version: '1.11.749'
-    implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: 'v0.3.0'
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: '0.3.4'
     implementation group: 'org.zalando', name: 'problem', version: '0.24.0'
     implementation group: 'org.apache.jena', name: 'jena', version: '3.14.0', ext: 'pom'
     implementation group: 'org.apache.jena', name: 'jena-arq', version: '3.14.0'

--- a/src/main/java/no/unit/nva/institution/proxy/HttpExecutorImpl.java
+++ b/src/main/java/no/unit/nva/institution/proxy/HttpExecutorImpl.java
@@ -26,6 +26,9 @@ import no.unit.nva.institution.proxy.utils.MapUtils;
 import no.unit.nva.institution.proxy.utils.UriUtils;
 import nva.commons.utils.JacocoGenerated;
 import nva.commons.utils.attempt.Failure;
+import nva.commons.utils.attempt.Try;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HttpExecutorImpl extends HttpExecutor {
 
@@ -34,7 +37,13 @@ public class HttpExecutorImpl extends HttpExecutor {
         "https://api.cristin.no/v2/institutions?country=NO" + "&per_page=1000000&lang=%s";
     public static final String PARENT_UNIT_URI_TEMPLATE =
         "https://api.cristin.no/v2/units?parent_unit_id=%s&per_page" + "=20000";
+    public static final int FIRST_EFFORT = 0;
+    public static final int MAX_EFFORTS = 2;
+    public static final int WAITING_TIME = 500; //500 milliseconds
+    public static final String LOG_INTERRUPTION = "InterruptedException while waiting to resend HTTP request";
     private final HttpClient httpClient;
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpExecutorImpl.class);
 
     /**
      * Default constructor.
@@ -52,20 +61,11 @@ public class HttpExecutorImpl extends HttpExecutor {
         this.httpClient = client;
     }
 
-    private CompletableFuture<HttpResponse<String>> sendHttpRequest(URI uri) {
-        HttpRequest httpRequest = HttpRequest.newBuilder()
-            .GET()
-            .header(ACCEPT, APPLICATION_JSON.getMimeType())
-            .header(USER_AGENT, NVA_INSTITUTIONS_LIST_CRAWLER)
-            .uri(uri)
-            .build();
-        return httpClient.sendAsync(httpRequest, BodyHandlers.ofString());
-    }
-
     @Override
     public InstitutionListResponse getInstitutions(Language language) throws HttpClientFailureException {
-        URI uri = URI.create(generateInstitutionsQueryUri(language));
-        return attempt(() -> sendHttpRequest(uri).get())
+
+        return attempt(() -> URI.create(generateInstitutionsQueryUri(language)))
+            .flatMap(this::sendRequestMultipleTimes)
             .map(this::throwExceptionIfNotSuccessful)
             .map(HttpResponse::body)
             .map(this::toInstitutionListResponse)
@@ -91,6 +91,54 @@ public class HttpExecutorImpl extends HttpExecutor {
         return generator.getNestedInstitution();
     }
 
+    private Try<HttpResponse<String>> sendRequestMultipleTimes(URI uri) {
+        return tryGettingResponse(uri, FIRST_EFFORT, null);
+    }
+
+    private Try<HttpResponse<String>> tryGettingResponse(URI uri, int effortCount,
+                                                         Try<HttpResponse<String>> lastEffort) {
+        if (lastEffortWasASuccessOrWeFailedTooManyTimes(effortCount, lastEffort)) {
+            return lastEffort;
+        } else {
+            if (effortCount > 0) {
+                waitBeforeRetrying();
+            }
+            Try<HttpResponse<String>> newEffort = attempt(() -> sendHttpRequest(uri).get());
+            if (newEffort.isFailure()) {
+                logger.warn("Failed HttpRequest:" + newEffort.getException().getMessage(), newEffort.getException());
+            }
+
+            return tryGettingResponse(uri, effortCount + 1, newEffort);
+        }
+    }
+
+    private CompletableFuture<HttpResponse<String>> sendHttpRequest(URI uri) {
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .GET()
+            .header(ACCEPT, APPLICATION_JSON.getMimeType())
+            .header(USER_AGENT, NVA_INSTITUTIONS_LIST_CRAWLER)
+            .uri(uri)
+            .build();
+        return httpClient.sendAsync(httpRequest, BodyHandlers.ofString());
+    }
+
+    private boolean lastEffortWasASuccessOrWeFailedTooManyTimes(int effortCount, Try<HttpResponse<String>> lastEffort) {
+        return lastEffort != null && (lastEffort.isSuccess() || haveTriedEnoughTimes(effortCount));
+    }
+
+    private boolean haveTriedEnoughTimes(int effortCount) {
+        return effortCount >= MAX_EFFORTS;
+    }
+
+    private void waitBeforeRetrying() {
+        try {
+            Thread.sleep(WAITING_TIME);
+        } catch (InterruptedException e) {
+            logger.error(LOG_INTERRUPTION);
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public JsonNode getSingleUnit(URI uri, Language language)
         throws InterruptedException, NonExistingUnitError, HttpClientFailureException {
@@ -105,20 +153,24 @@ public class HttpExecutorImpl extends HttpExecutor {
     }
 
     private SubSubUnitDto getSubSubUnitDto(URI subunitUri, Language language) throws HttpClientFailureException {
-        return attempt(() -> sendHttpRequest(UriUtils.getUriWithLanguage(subunitUri, language)).get())
-            .map(this::throwExceptionIfNotSuccessful)
-            .map(HttpResponse::body)
-            .map(InstitutionUtils::toSubSubUnitDto)
-            .orElseThrow(this::handleError);
+        return
+            Try.of(UriUtils.getUriWithLanguage(subunitUri, language))
+                .flatMap(this::sendRequestMultipleTimes)
+                .map(this::throwExceptionIfNotSuccessful)
+                .map(HttpResponse::body)
+                .map(InstitutionUtils::toSubSubUnitDto)
+                .orElseThrow(this::handleError);
     }
 
     private List<URI> getUnitUris(String id, Language language) throws HttpClientFailureException {
-        URI uri = UriUtils.getUriWithLanguage(URI.create(String.format(PARENT_UNIT_URI_TEMPLATE, id)), language);
-        return attempt(() -> sendHttpRequest(uri).get())
-            .map(this::throwExceptionIfNotSuccessful)
-            .map(HttpResponse::body)
-            .map(this::bodyToUriList)
-            .orElseThrow(this::handleError);
+        return
+            attempt(
+                () -> UriUtils.getUriWithLanguage(URI.create(String.format(PARENT_UNIT_URI_TEMPLATE, id)), language))
+                .flatMap(this::sendRequestMultipleTimes)
+                .map(this::throwExceptionIfNotSuccessful)
+                .map(HttpResponse::body)
+                .map(this::bodyToUriList)
+                .orElseThrow(this::handleError);
     }
 
     private List<URI> bodyToUriList(String json) throws IOException {
@@ -126,11 +178,13 @@ public class HttpExecutorImpl extends HttpExecutor {
     }
 
     private InstitutionBaseDto getInstitutionBaseDto(URI uri, Language language) throws HttpClientFailureException {
-        return attempt(() -> sendHttpRequest(UriUtils.getUriWithLanguage(uri, language)).get())
-            .map(this::throwExceptionIfNotSuccessful)
-            .map(HttpResponse::body)
-            .map(this::toInstitutionBaseDto)
-            .orElseThrow(this::handleError);
+        return
+            attempt(() -> UriUtils.getUriWithLanguage(uri, language))
+                .flatMap(this::sendRequestMultipleTimes)
+                .map(this::throwExceptionIfNotSuccessful)
+                .map(HttpResponse::body)
+                .map(this::toInstitutionBaseDto)
+                .orElseThrow(this::handleError);
     }
 
     private InstitutionBaseDto toInstitutionBaseDto(String json) throws IOException {
@@ -138,7 +192,7 @@ public class HttpExecutorImpl extends HttpExecutor {
     }
 
     private <T> HttpClientFailureException handleError(Failure<T> failure) {
-        return new HttpClientFailureException(failure.getException());
+        return new HttpClientFailureException(failure.getException(), failure.getException().getMessage());
     }
 
     private InstitutionListResponse toInstitutionListResponse(String institutionDto) throws IOException {

--- a/src/main/java/no/unit/nva/institution/proxy/exception/HttpClientFailureException.java
+++ b/src/main/java/no/unit/nva/institution/proxy/exception/HttpClientFailureException.java
@@ -15,6 +15,10 @@ public class HttpClientFailureException extends ApiGatewayException {
         super(cause);
     }
 
+    public HttpClientFailureException(Exception cause, String message) {
+        super(cause, message);
+    }
+
     @Override
     protected Integer statusCode() {
         return ERROR_CODE;

--- a/src/test/java/no/unit/nva/institution/proxy/HttpExecutorImplTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/HttpExecutorImplTest.java
@@ -24,6 +24,7 @@ import java.net.http.HttpResponse.BodyHandler;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import no.unit.nva.institution.proxy.exception.FailedHttpRequestException;
 import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import testutils.HttpClientGetsNestedInstitutionResponse;
 import testutils.HttpClientReturningInfoOfSingleUnits;
+import testutils.HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond;
 
 public class HttpExecutorImplTest {
 
@@ -154,6 +156,22 @@ public class HttpExecutorImplTest {
         HttpExecutorImpl executor = new HttpExecutorImpl(client);
         JsonNode response = executor.getNestedInstitution(URI.create(INSTITUTION_REQUEST_URI),
             Language.ENGLISH);
+        JsonNode expectedJson =
+            JsonUtils.objectMapper.readTree(
+                IoUtils.inputStreamFromResources(EXPECTED_NESTED_INSTITUTION_FOR_VALID_REQUEST));
+        assertThat(response, is(equalTo(expectedJson)));
+    }
+
+    @DisplayName("getNestedInstitutions returns success when HttpClient throws exception in first attempt succeeds"
+        + "in the second")
+    @Test
+    public void getNestedInstitutionsReturnsSuccessWhenHttpClientThrowsExceptionInFirstAttemptAndSucceedsInTheSecond()
+        throws InterruptedException, ExecutionException, InvalidUriException, HttpClientFailureException, IOException {
+        HttpClient client = new HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond().getClient();
+        HttpExecutorImpl executor = new HttpExecutorImpl(client);
+        JsonNode response = executor.getNestedInstitution(URI.create(INSTITUTION_REQUEST_URI),
+            Language.ENGLISH);
+
         JsonNode expectedJson =
             JsonUtils.objectMapper.readTree(
                 IoUtils.inputStreamFromResources(EXPECTED_NESTED_INSTITUTION_FOR_VALID_REQUEST));

--- a/src/test/java/testutils/HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond.java
+++ b/src/test/java/testutils/HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond.java
@@ -1,0 +1,71 @@
+package testutils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import no.unit.nva.institution.proxy.exception.InvalidUriException;
+import no.unit.nva.institution.proxy.utils.Language;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+
+public class HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond {
+
+    public static final String SOME_MESSAGE = "Some message";
+    private HttpClient client = Mockito.mock(HttpClient.class);
+
+    private HttpClient clientForNestedQueries;
+
+    private int requestCounter = 0;
+
+    public HttpClientThrowsExceptionInFirstRequestButSucceedsInSecond()
+        throws InterruptedException, ExecutionException, InvalidUriException {
+        setup();
+    }
+
+    private void setup() throws InvalidUriException {
+        clientForNestedQueries = new HttpClientGetsNestedInstitutionResponse(Language.ENGLISH)
+            .getMockClient();
+
+        when(client.sendAsync(any(HttpRequest.class), any(BodyHandler.class)))
+            .thenAnswer(this::manageReturnedResponse);
+    }
+
+    private CompletableFuture<HttpResponse<String>> manageReturnedResponse(InvocationOnMock invocation)
+        throws ExecutionException, InterruptedException {
+        if (requestCounter == 0) {
+            prepareToReturnSuccessOnNextCall();
+            return futureThrowingException();
+        } else {
+            return returnSuccessfulResponse(invocation);
+        }
+    }
+
+    private void prepareToReturnSuccessOnNextCall() {
+        requestCounter++;
+    }
+
+    private CompletableFuture<HttpResponse<String>> returnSuccessfulResponse(InvocationOnMock invocation) {
+        HttpRequest request = invocation.getArgument(0);
+        BodyHandler<String> handler = invocation.getArgument(1);
+        return clientForNestedQueries.sendAsync(request, handler);
+    }
+
+    private CompletableFuture<HttpResponse<String>> futureThrowingException()
+        throws ExecutionException, InterruptedException {
+        CompletableFuture<HttpResponse<String>> mockFuture = mock(CompletableFuture.class);
+        when(mockFuture.get()).thenThrow(new ExecutionException(new IOException(SOME_MESSAGE)));
+        return mockFuture;
+    }
+
+    public HttpClient getClient() {
+        return client;
+    }
+}


### PR DESCRIPTION
Error to fix: When we receive a GOAWAY frame from CRISTIN or other servers, HttpClient throws an ExecutionException and  we send an error back to our REST-API client.

Fix: Wait for 500 msec, and then retry to get the data. If the HttpClient throws an Exception, then we try again and if HttpClient throws an Exception again then we send an error message back to our REST-API clients.

Changes:
1. upgrade nva-commons.
2. Update HttpExecutorImpl to retry in case of an ExectutionException.
3. Log the error as a warning.
