### PR TITLE
Add caching and small typo fixes

### DIFF
--- a/src/main/java/no/unit/nva/institution/proxy/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/institution/proxy/CristinApiClient.java
@@ -1,7 +1,6 @@
 package no.unit.nva.institution.proxy;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.net.URI;
 import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
 import no.unit.nva.institution.proxy.exception.InvalidUriException;
 import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
@@ -9,6 +8,8 @@ import no.unit.nva.institution.proxy.response.InstitutionListResponse;
 import no.unit.nva.institution.proxy.utils.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URI;
 
 public class CristinApiClient {
 
@@ -28,7 +29,7 @@ public class CristinApiClient {
     }
 
     /**
-     * Get all the descendants of an insitution's logical unit.
+     * Get all the descendants of an institution's logical unit.
      *
      * @param uri      The URI of the institution's Unit
      * @param language a valid Language. See {@link Language}.
@@ -54,7 +55,6 @@ public class CristinApiClient {
     public JsonNode getSingleUnit(URI uri, Language language)
         throws InterruptedException, NonExistingUnitError, HttpClientFailureException {
         logger.info("Fetching resutls for: " + uri.toString());
-        JsonNode result = httpExecutor.getSingleUnit(uri, language);
-        return result;
+        return httpExecutor.getSingleUnit(uri, language);
     }
 }

--- a/src/main/java/no/unit/nva/institution/proxy/handler/InstitutionListHandler.java
+++ b/src/main/java/no/unit/nva/institution/proxy/handler/InstitutionListHandler.java
@@ -13,10 +13,13 @@ import nva.commons.utils.JacocoGenerated;
 import org.apache.http.HttpStatus;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Objects.isNull;
+
 public class InstitutionListHandler extends ApiGatewayHandler<Void, InstitutionListResponse> {
 
     public static final String LANGUAGE_QUERY_PARAMETER = "language";
     private final CristinApiClient cristinApiClient;
+    private InstitutionListResponse response;
 
     @JacocoGenerated
     public InstitutionListHandler() {
@@ -37,7 +40,10 @@ public class InstitutionListHandler extends ApiGatewayHandler<Void, InstitutionL
         throws UnknownLanguageException, HttpClientFailureException {
         String languageParameter = requestInfo.getQueryParameters().get(LANGUAGE_QUERY_PARAMETER);
         LanguageMapper languageMapper = new LanguageMapper();
-        return cristinApiClient.getInstitutions(languageMapper.getLanguage(languageParameter));
+        if (isNull(response)) {
+            response = cristinApiClient.getInstitutions(languageMapper.getLanguage(languageParameter));
+        }
+        return response;
     }
 
     @Override

--- a/src/test/java/no/unit/nva/institution/proxy/CristinApiClientTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/CristinApiClientTest.java
@@ -1,5 +1,24 @@
 package no.unit.nva.institution.proxy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
+import no.unit.nva.institution.proxy.exception.InvalidUriException;
+import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
+import no.unit.nva.institution.proxy.response.InstitutionListResponse;
+import no.unit.nva.institution.proxy.response.InstitutionResponse;
+import no.unit.nva.institution.proxy.utils.Language;
+import nva.commons.utils.IoUtils;
+import nva.commons.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import testutils.HttpClientReturningInfoOfSingleUnits;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -12,30 +31,10 @@ import static org.mockito.Mockito.when;
 import static testutils.HttpClientReturningInfoOfSingleUnits.SECOND_LEVEL_CHILD_URI;
 import static testutils.HttpClientReturningInfoOfSingleUnits.TESTING_LANGUAGE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.net.URI;
-import java.nio.file.Path;
-import java.util.Collections;
-import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
-import no.unit.nva.institution.proxy.exception.InvalidUriException;
-import no.unit.nva.institution.proxy.exception.JsonParsingException;
-import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
-import no.unit.nva.institution.proxy.response.InstitutionListResponse;
-import no.unit.nva.institution.proxy.response.InstitutionResponse;
-import no.unit.nva.institution.proxy.utils.Language;
-import nva.commons.utils.IoUtils;
-import nva.commons.utils.JsonUtils;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import testutils.HttpClientReturningInfoOfSingleUnits;
-
 public class CristinApiClientTest {
 
     public static final Language VALID_LANGUAGE_EN = Language.ENGLISH;
     public static final URI VALID_URI = URI.create("https://example.org");
-    public static final String JSON_VALUE = "true";
     public static final String SOME_NAME = "SomeName";
     public static final String HTTP_CLIENT_RESPONSES = "httpClientResponses";
     public static final Path SINGLE_UNIT_RESPONSE_GRAPH = Path.of(HTTP_CLIENT_RESPONSES,
@@ -47,7 +46,7 @@ public class CristinApiClientTest {
     @DisplayName("getNestedInstitution returns nested institution when input is valid")
     @Test
     void getNestedInstitutionReturnsNestedInstitutionWhenInputIsValid()
-        throws InvalidUriException, HttpClientFailureException, JsonParsingException {
+        throws InvalidUriException, HttpClientFailureException {
         HttpExecutor mockHttpExecutor = mock(HttpExecutorImpl.class);
         ObjectNode mockResponse = simpleJsonObject();
         when(mockHttpExecutor.getNestedInstitution(any(), any()))

--- a/src/test/java/no/unit/nva/institution/proxy/NestedInstitutionRequestTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/NestedInstitutionRequestTest.java
@@ -1,17 +1,17 @@
 package no.unit.nva.institution.proxy;
 
-import static org.junit.Assert.assertNotNull;
-
 import no.unit.nva.institution.proxy.request.NestedInstitutionRequest;
 import no.unit.nva.institution.proxy.utils.Language;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.Assert.assertNotNull;
+
 public class NestedInstitutionRequestTest {
 
     @DisplayName("NestedInstitutionRequest has a constructor with parameters")
     @Test
-    public void nestedInstitutionRequestHasAConstuctorWithParameters() {
+    public void nestedInstitutionRequestHasAConstructorWithParameters() {
         NestedInstitutionRequest actual = new NestedInstitutionRequest("SomeUrl", Language.ENGLISH.getCode());
         assertNotNull(actual);
     }

--- a/src/test/java/no/unit/nva/institution/proxy/SingleUnitHierarchyGeneratorTest.java
+++ b/src/test/java/no/unit/nva/institution/proxy/SingleUnitHierarchyGeneratorTest.java
@@ -1,5 +1,33 @@
 package no.unit.nva.institution.proxy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
+import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
+import nva.commons.utils.IoUtils;
+import nva.commons.utils.JsonUtils;
+import nva.commons.utils.attempt.Try;
+import org.apache.http.HttpStatus;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import testutils.HttpClientReturningInfoOfSingleUnits;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static no.unit.nva.institution.proxy.utils.UriUtils.clearParameters;
 import static nva.commons.utils.attempt.Try.attempt;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -16,35 +44,6 @@ import static testutils.HttpClientReturningInfoOfSingleUnits.ROOT_NODE_URI;
 import static testutils.HttpClientReturningInfoOfSingleUnits.SECOND_LEVEL_CHILD_URI;
 import static testutils.HttpClientReturningInfoOfSingleUnits.TESTING_LANGUAGE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandler;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import no.unit.nva.institution.proxy.exception.HttpClientFailureException;
-import no.unit.nva.institution.proxy.exception.InvalidUriException;
-import no.unit.nva.institution.proxy.exception.JsonParsingException;
-import no.unit.nva.institution.proxy.exception.NonExistingUnitError;
-import nva.commons.utils.IoUtils;
-import nva.commons.utils.JsonUtils;
-import nva.commons.utils.attempt.Try;
-import org.apache.http.HttpStatus;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Resource;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-import testutils.HttpClientReturningInfoOfSingleUnits;
-
 public class SingleUnitHierarchyGeneratorTest {
 
     public static final String JSONLD = "JSONLD";
@@ -55,9 +54,7 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with single item when input item has no parents")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithSingleItemWhenInputItemHasNoParents()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
-               JsonParsingException,
-               JsonProcessingException {
+        throws InterruptedException, NonExistingUnitError, HttpClientFailureException, JsonProcessingException {
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(ROOT_NODE_URI, TESTING_LANGUAGE,
             mockHttpClient);
         JsonNode jsonLd = generator.toJsonLd();
@@ -69,8 +66,7 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with two items when input item is a level one child")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithTwoItemsWhenInputItemIsALevelOneChild()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
-               JsonProcessingException, JsonParsingException {
+        throws InterruptedException, NonExistingUnitError, HttpClientFailureException, JsonProcessingException {
 
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(FIRST_LEVEL_CHILD_URI,
             TESTING_LANGUAGE, mockHttpClient);
@@ -82,9 +78,7 @@ public class SingleUnitHierarchyGeneratorTest {
     @DisplayName("SingleUnitHierarchyGenerator returns model with 3 items when input item is a level two child")
     @Test
     public void singleUnitHierarchyGeneratorReturnsModelWithThreeItemsWhenInputItemIsALevelTwoChild()
-        throws InterruptedException, InvalidUriException, NonExistingUnitError, HttpClientFailureException,
-               JsonParsingException,
-               JsonProcessingException {
+        throws InterruptedException, NonExistingUnitError, HttpClientFailureException, JsonProcessingException {
 
         SingleUnitHierarchyGenerator generator = new SingleUnitHierarchyGenerator(SECOND_LEVEL_CHILD_URI,
             TESTING_LANGUAGE, mockHttpClient);

--- a/src/test/resources/events/nested_institutions_request_with_unit_with_valid_parameters.json
+++ b/src/test/resources/events/nested_institutions_request_with_unit_with_valid_parameters.json
@@ -1,0 +1,27 @@
+{
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "application/json",
+    "Accept-Encoding": "gzip, deflate, sdch, br",
+    "Accept-Language": "en-UK,en;q=0.8",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "xxxxxxxxxx.execute-api.eu-west-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "FAKE-API-CRAWLER",
+    "Via": "1.1 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxx_xxxx==",
+    "X-Forwarded-For": "11.111.111.111, 11.111.111.111",
+    "X-Forwarded-Port": "111",
+    "X-Forwarded-Proto": "http"
+  },
+  "queryStringParameters": {
+    "language": "en",
+    "uri": "http://get-info.no/units"
+  }
+}


### PR DESCRIPTION
A naïve attempt to fix the problem of actually needing a cache because certain requests will always time out in API gateway.

If the same object is requested twice, it should now return more rapidly.

- Added caching to Institutions
- Added caching to nested units
- Fixed some small typos and inlined a few bits.

Probably look at the testing here, because it is likely stupid and will not work in test circumstances if test running variables change. I am open to suggestions.